### PR TITLE
fix(sdk): Fixes for Identifying Untagged Images for Running

### DIFF
--- a/sdk/python/kfp/local/docker_task_handler.py
+++ b/sdk/python/kfp/local/docker_task_handler.py
@@ -78,13 +78,12 @@ def run_docker_container(
 ) -> int:
     image = add_latest_tag_if_not_present(image=image)
     image_exists = any(
-        image in existing_image.tags for existing_image in client.images.list())
+        image in (existing_image.tags+existing_image.attrs['RepoDigests']) for existing_image in client.images.list())
     if image_exists:
         print(f'Found image {image!r}\n')
     else:
         print(f'Pulling image {image!r}')
-        repository, tag = image.split(':')
-        client.images.pull(repository=repository, tag=tag)
+        client.images.pull(image)
         print('Image pull complete\n')
     container = client.containers.run(
         image=image,

--- a/sdk/python/kfp/local/docker_task_handler.py
+++ b/sdk/python/kfp/local/docker_task_handler.py
@@ -78,7 +78,8 @@ def run_docker_container(
 ) -> int:
     image = add_latest_tag_if_not_present(image=image)
     image_exists = any(
-        image in (existing_image.tags+existing_image.attrs['RepoDigests']) for existing_image in client.images.list())
+        image in (existing_image.tags+existing_image.attrs['RepoDigests'])
+        for existing_image in client.images.list())
     if image_exists:
         print(f'Found image {image!r}\n')
     else:


### PR DESCRIPTION
**Description of your changes:**
In trying to [execute pipelines locally](https://www.kubeflow.org/docs/components/pipelines/user-guides/core-functions/execute-kfp-pipelines-locally/), I found that the docker utilities in the SDK don't account for the situation where the docker images of interest are entirely untagged.

**Steps to reproduce:**
```bash
export IMAGE="hello-world@sha256:a77ecd852b17bfaee6708208960645d20fc9e6d0eec12353f8eb0e7b94bb647a"
docker pull $IMAGE
python
```

```py
import os
import docker
from kfp.local.docker_task_handler import run_docker_container

docker_client = docker.from_env()
image = os.getenv("IMAGE")

run_docker_container(docker_client, image, [], {})
```

**Existing error:**

<details>

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/alex.bieniek/work/kubeflow-pipelines/sdk/python/kfp/local/docker_task_handler.py", line 87, in run_docker_container
    client.images.pull(repository=repository, tag=tag)
  File "/Users/alex.bieniek/work/elc/dsa-go/venv-ci/lib/python3.11/site-packages/docker/models/images.py", line 464, in pull
    pull_log = self.client.api.pull(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex.bieniek/work/elc/dsa-go/venv-ci/lib/python3.11/site-packages/docker/api/image.py", line 429, in pull
    self._raise_for_status(response)
  File "/Users/alex.bieniek/work/elc/dsa-go/venv-ci/lib/python3.11/site-packages/docker/api/client.py", line 277, in _raise_for_status
    raise create_api_error_from_http_exception(e) from e
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex.bieniek/work/elc/dsa-go/venv-ci/lib/python3.11/site-packages/docker/errors.py", line 39, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation) from e
docker.errors.NotFound: 404 Client Error for http+docker://localhost/v1.47/images/create?tag=a77ecd852b17bfaee6708208960645d20fc9e6d0eec12353f8eb0e7b94bb647a&fromImage=hello-world: Not Found ("manifest for hello-world:a77ecd852b17bfaee6708208960645d20fc9e6d0eec12353f8eb0e7b94bb647a not found: manifest unknown: manifest unknown")
```

</details>


**With fixes:**
<details>

```
Pulling image 'hello-world:linux'
Image pull complete


Hello from Docker!
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
    (arm64v8)
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

Share images, automate workflows, and more with a free Docker ID:
 https://hub.docker.com/

For more examples and ideas, visit:
 https://docs.docker.com/get-started/

0

```

</details>

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 